### PR TITLE
Discourage the use of Em.A

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@
     var items = [];
     ```
 
+    *NOTE:* using an `Em.A()` or `Ember.A()` is discourage and we should favor the literal syntax array creation. See [Em.A](http://emberjs.com/api/#method_A).
+
   - If you don't know array length use Array#push.
 
     ```javascript


### PR DESCRIPTION
Em.A isn't redundant and just makes our code more verbose without adding any functionality. From [Ember.A](http://emberjs.com/api/classes/Ember.html#method_A)

```
Creates an Ember.NativeArray from an Array like object. Does not modify the original object. Ember.A is not needed if Ember.EXTEND_PROTOTYPES is true (the default value). However, it is recommended that you use Ember.A when creating addons for ember or when you can not guarantee that Ember.EXTEND_PROTOTYPES will be true.
```

Unless we're not sure something is an array (e.g. function arguments) I think we should avoid it. 

Unless there're some issues, I think it's better to deprecate the use. Extending the prototype makes this two objects the same. See as a reference:

![EmA](https://s3.amazonaws.com/uploads.hipchat.com/22555/778938/Cxto4Qy7c52fQhS/upload.png)
