### PR TITLE
Increases char length to 140

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@
     var fullName = 'Bob ' + this.lastName;
     ```
 
-  - Strings longer than 80 characters should be written across multiple lines using string concatenation.
+  - Strings longer than 140 characters should be written across multiple lines using string concatenation.
   - Note: If overused, long strings with concatenation could impact performance. [jsPerf](http://jsperf.com/ya-string-concat) & [Discussion](https://github.com/airbnb/javascript/issues/40)
 
     ```javascript
@@ -734,7 +734,7 @@
     function() {
     ∙var name;
     }
-    
+
     // bad
     function() {
     ∙∙var name;
@@ -1283,7 +1283,7 @@
 
 ## Modules
 
-** Note: ** We can ignore this section since the ES6 transpiler adds 'use strict' for us, doesn't require the trailing `!` and ember forces us to use dashs for file names. 
+** Note: ** We can ignore this section since the ES6 transpiler adds 'use strict' for us, doesn't require the trailing `!` and ember forces us to use dashs for file names.
 
   - The module should start with a `!`. This ensures that if a malformed module forgets to include a final semicolon there aren't errors in production when the scripts get concatenated. [Explanation](https://github.com/airbnb/javascript/issues/44#issuecomment-13063933)
   - The file should be named-with-dashes, live in a folder with the same name, and match the name of the single export.
@@ -1315,9 +1315,9 @@
 
 ## File Names
 
-** Note: ** this section isn't part of the original AirBnB guide. 
+** Note: ** this section isn't part of the original AirBnB guide.
 
-- We use file-names-with-dashes because that's required for templates and components by Ember and EAK and ember-cli do that by default. 
+- We use file-names-with-dashes because that's required for templates and components by Ember and EAK and ember-cli do that by default.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
There have been some complains about this rule now that it's actually enforce. Currently the styleguide says 80, our jshintrc says 120. I think it's reasonable to bump it to 140. Others think this rules is completely unnecessary and shouldn't be enforced.

What do you think?